### PR TITLE
improved strong-typing of alloy apps

### DIFF
--- a/templates/typescript-alloy-app/app/globals.d.ts
+++ b/templates/typescript-alloy-app/app/globals.d.ts
@@ -2,18 +2,13 @@ type NonFunctionPropertyNames<T> = { [K in keyof T]: T[K] extends Function ? nev
 type NonFunctionProperties<T> = Pick<T, NonFunctionPropertyNames<T>>;
 type Dictionary<T> = Partial<NonFunctionProperties<T>>;
 
-/**
- * Reference to the current controller instance.
- */
-declare const $: AlloyController;
+declare interface JQueryStatic extends AlloyController {
+}
 
 /**
  * The base class for Alloy controllers.
  */
-declare interface AlloyController {
-
-  [k: string]: any;
-
+declare interface AlloyController extends Backbone.Model {
   /**
    *
    * @param proxy View object to which to add class(es).

--- a/templates/typescript-alloy-app/app/globals.d.ts
+++ b/templates/typescript-alloy-app/app/globals.d.ts
@@ -129,7 +129,7 @@ declare interface AlloyInterface {
   /**
    * true if the current device is a tablet.
    */
-  isTabled: boolean
+  isTablet: boolean
 
   /**
    * Factory method for instantiating a Backbone collection of model objects. Creates and returns a collection for holding the named type of model objects.

--- a/templates/typescript-alloy-app/package-lock.json
+++ b/templates/typescript-alloy-app/package-lock.json
@@ -4,10 +4,41 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@types/backbone": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/@types/backbone/-/backbone-1.4.1.tgz",
+      "integrity": "sha512-KYfGuQy4d2vvYXbn0uHFZ6brFLndatTMomxBlljpbWf4kFpA3BG/6LA3ec+J9iredrX6eAVI7sm9SVAvwiIM6g==",
+      "dev": true,
+      "requires": {
+        "@types/jquery": "*",
+        "@types/underscore": "*"
+      }
+    },
+    "@types/jquery": {
+      "version": "3.3.31",
+      "resolved": "https://registry.npmjs.org/@types/jquery/-/jquery-3.3.31.tgz",
+      "integrity": "sha512-Lz4BAJihoFw5nRzKvg4nawXPzutkv7wmfQ5121avptaSIXlDNJCUuxZxX/G+9EVidZGuO0UBlk+YjKbwRKJigg==",
+      "dev": true,
+      "requires": {
+        "@types/sizzle": "*"
+      }
+    },
+    "@types/sizzle": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/@types/sizzle/-/sizzle-2.3.2.tgz",
+      "integrity": "sha512-7EJYyKTL7tFR8+gDbB6Wwz/arpGa0Mywk1TJbNzKzHtzbwVmY4HR9WqS5VV7dsBUKQmPNr192jHr/VpBluj/hg==",
+      "dev": true
+    },
     "@types/titanium": {
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/@types/titanium/-/titanium-7.1.0.tgz",
       "integrity": "sha512-zn7c73BbqG0eibG5F8g2PdUrTeSbVPYQpB5YZuRMCJf60jyqnrT4M+ee5yGpOEszW3wuIX7SGyktcg6OHnfkQg==",
+      "dev": true
+    },
+    "@types/underscore": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/@types/underscore/-/underscore-1.9.3.tgz",
+      "integrity": "sha512-SwbHKB2DPIDlvYqtK5O+0LFtZAyrUSw4c0q+HWwmH1Ve3KMQ0/5PlV3RX97+3dP7yMrnNQ8/bCWWvQpPl03Mug==",
       "dev": true
     },
     "ansi-regex": {

--- a/templates/typescript-alloy-app/package.json
+++ b/templates/typescript-alloy-app/package.json
@@ -10,6 +10,7 @@
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "devDependencies": {
+    "@types/backbone": "^1.4.1",
     "@types/titanium": "^7.1.0",
     "tslint": "^5.11.0",
     "typescript": "^3.0.1"


### PR DESCRIPTION
Included Backbone types, and made `AlloyController` extend from `Backbone.Model`.

Also extended the `JQueryStatic` interface already defining the global `$` variable, to extend from `AlloyController` as well.

This improves the type safety quite a lot.